### PR TITLE
More flexible local FS

### DIFF
--- a/Libraries/Plasmacore/SDL/plasmacore.cpp
+++ b/Libraries/Plasmacore/SDL/plasmacore.cpp
@@ -20,7 +20,6 @@
 #include <unistd.h>
 #endif
 
-#define LOCAL_FS 1
 //#define WINDOW_BASED 1
 
 // The "code" value for SDL_USEREVENT for our async call mechanism
@@ -462,9 +461,10 @@ int main (int argc, char * argv[])
 
 #ifdef __EMSCRIPTEN__
   #ifdef LOCAL_FS
-    EM_ASM(
-       FS.mkdir("/local_storage");
-       FS.mount(IDBFS, {}, "/local_storage");
+    EM_ASM_({
+       var mountpoint = Module["Pointer_stringify"]($0);
+       FS.mkdir(mountpoint);
+       FS.mount(IDBFS, {}, mountpoint);
        FS.syncfs(true, function (err) {
          Module.print("Persistent storage ready.");
          Module["_start_main_loop"]();
@@ -474,7 +474,7 @@ int main (int argc, char * argv[])
          FS.syncfs(false, function(err) {});
          return null;
        });
-    );
+    }, LOCAL_FS);
   #else
     start_main_loop();
   #endif

--- a/Platforms/Web/Makefile
+++ b/Platforms/Web/Makefile
@@ -50,6 +50,7 @@ $(BUILD_FOLDER)/$(OUTPUT_NAME).html: $(BUILD_FOLDER)/Source/RogueProgram.cpp $(S
 	       -s USE_SDL=2 \
 	       -s USE_LIBPNG=1 \
 	       -s EXPORTED_FUNCTIONS="['_main', '_malloc', '_start_main_loop']" \
+	       -D LOCAL_FS='"/local_storage"' \
 	       -std=c++11 \
 	       --preload-file $(BUILD_FOLDER)/Assets@/Assets \
 	       -Wall \


### PR DESCRIPTION
The name of the local storage filesystem used to be hard-coded as
/local_storage, and the feature used to be always on unless you
altered plasmacore.cpp.  Now, you define the path using the
Makefile with -D LOCAL_FS="/path_name", which is done by default
to match the old behavior.  If it's not specified, local storage
isn't configured automatically.